### PR TITLE
Feat/item page or concert details [Layout ONLY]

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,18 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script
+      type="module"
+      src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.esm.js"
+    ></script>
+    <script
+      nomodule
+      src="https://unpkg.com/ionicons@7.1.0/dist/ionicons/ionicons.js"
+    ></script>
     <title>Vite + React</title>
   </head>
   <body>

--- a/src/components/ItemDataPanel.jsx
+++ b/src/components/ItemDataPanel.jsx
@@ -2,40 +2,44 @@ import RoundedButton from './buttons/RoundedButton';
 
 function ItemDataPanel() {
   return (
-    <section className="flex flex-col gap-5 md:justify-evenly md:h-3/4 m-2 p-x-2 p-y-6 md:w-1/3">
-      <div>
-        <h1 className="text-xl text-end font-bold">
-          Mozart&apos;s tribute concert
-        </h1>
-        <p className="text-sm text-right">
-          Enjoy of a Mozart presentation with 3d visual effect rendering mozart
-          like live action generated with AI
-        </p>
-      </div>
+    <section className="flex flex-col gap-5 md:justify-between md:h-2/3 m-2 p-x-2 p-y-6">
+      <div className="flex flex-col gap-5 ">
+        <div>
+          <h1 className="text-xl text-end font-bold">
+            Mozart&apos;s tribute concert
+          </h1>
+          <p className="text-sm text-right">
+            Enjoy of a Mozart presentation with 3d visual effect rendering
+            mozart like live action generated with AI
+          </p>
+        </div>
 
-      <div className="container shadow-md">
-        <table className="text-sm w-full">
-          <tbody>
-            <tr className="bg-neutral-100">
-              <td>Organized by:</td>
-              <td>Mr.Rock</td>
-            </tr>
-            <tr>
-              <td>Date:</td>
-              <td>11-Jan-2100</td>
-            </tr>
-            <tr className="bg-neutral-100">
-              <td>City:</td>
-              <td>New York</td>
-            </tr>
-            <tr>
-              <td>Price:</td>
-              <td>$ 120.00</td>
-            </tr>
-          </tbody>
-        </table>
+        <div className="container shadow-md">
+          <table className="text-sm w-full">
+            <tbody>
+              <tr className="bg-neutral-100">
+                <td>Organized by:</td>
+                <td>Mr.Rock</td>
+              </tr>
+              <tr>
+                <td>Date:</td>
+                <td>11-Jan-2100</td>
+              </tr>
+              <tr className="bg-neutral-100">
+                <td>City:</td>
+                <td>New York</td>
+              </tr>
+              <tr>
+                <td>Price:</td>
+                <td>$ 120.00</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
-      <RoundedButton text="Reserve" />
+      <div className="container flex justify-end  w-full">
+        <RoundedButton text="Reserve" />
+      </div>
     </section>
   );
 }

--- a/src/components/ItemDataPanel.jsx
+++ b/src/components/ItemDataPanel.jsx
@@ -1,0 +1,43 @@
+import RoundedButton from './buttons/RoundedButton';
+
+function ItemDataPanel() {
+  return (
+    <section className="flex flex-col gap-5 md:justify-evenly md:h-3/4 m-2 p-x-2 p-y-6 md:w-1/3">
+      <div>
+        <h1 className="text-xl text-end font-bold">
+          Mozart&apos;s tribute concert
+        </h1>
+        <p className="text-sm text-right">
+          Enjoy of a Mozart presentation with 3d visual effect rendering mozart
+          like live action generated with AI
+        </p>
+      </div>
+
+      <div className="container shadow-md">
+        <table className="text-sm w-full">
+          <tbody>
+            <tr className="bg-neutral-100">
+              <td>Organized by:</td>
+              <td>Mr.Rock</td>
+            </tr>
+            <tr>
+              <td>Date:</td>
+              <td>11-Jan-2100</td>
+            </tr>
+            <tr className="bg-neutral-100">
+              <td>City:</td>
+              <td>New York</td>
+            </tr>
+            <tr>
+              <td>Price:</td>
+              <td>$ 120.00</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <RoundedButton text="Reserve" />
+    </section>
+  );
+}
+
+export default ItemDataPanel;

--- a/src/components/buttons/LeftButton.jsx
+++ b/src/components/buttons/LeftButton.jsx
@@ -1,0 +1,15 @@
+function LeftButton() {
+  return (
+    <button
+      className="flex items-center justify-end text-xl w-16 md:w-20 py-1 
+  bg-[#94bc0c] border-white border-solid border-2 text-white
+rounded-r-xl md:rounded-r-2xl px-4
+hover:bg-slate-100 hover:text-[#94bc0c] hover:border-[#94bc0c]
+transition duration-500 ease-in-out"
+    >
+      <ion-icon name="chevron-back-outline"></ion-icon>
+    </button>
+  );
+}
+
+export default LeftButton;

--- a/src/components/buttons/RightButton.jsx
+++ b/src/components/buttons/RightButton.jsx
@@ -1,0 +1,16 @@
+function RightButton() {
+    return (
+      <button
+        className="flex items-center justify-end text-xl w-16 md:w-20 py-1 
+    bg-[#94bc0c] border-white border-solid border-2 text-white
+  rounded-l-xl md:rounded-l-2xl px-4
+  hover:bg-slate-100 hover:text-[#94bc0c] hover:border-[#94bc0c]
+  transition duration-500 ease-in-out"
+      >
+        <ion-icon name="chevron-back-outline"></ion-icon>
+      </button>
+    );
+  }
+  
+  export default RightButton;
+  

--- a/src/components/buttons/RightButton.jsx
+++ b/src/components/buttons/RightButton.jsx
@@ -7,7 +7,7 @@ function RightButton() {
   hover:bg-slate-100 hover:text-[#94bc0c] hover:border-[#94bc0c]
   transition duration-500 ease-in-out"
       >
-        <ion-icon name="chevron-back-outline"></ion-icon>
+        <ion-icon name="chevron-forward-outline"></ion-icon>
       </button>
     );
   }

--- a/src/components/buttons/RoundedButton.jsx
+++ b/src/components/buttons/RoundedButton.jsx
@@ -1,0 +1,26 @@
+import PropTypes from 'prop-types';
+
+function RoundedButton({ text }) {
+  return (
+    <button
+      className="container flex space-x-2 items-center w-28 md:w-40 py-1
+        bg-[#94bc0c] border-white border-solid border-2 text-white
+      rounded-xl md:rounded-2xl px-4
+      hover:bg-slate-100 hover:text-[#94bc0c] hover:border-[#94bc0c]
+      transition duration-500 ease-in-out"
+    >
+      <span className="text-xs md:text-xl">{text}</span>
+      <ion-icon
+        name="arrow-forward-circle-outline"
+        className="text-xl"
+      ></ion-icon>
+    </button>
+  );
+}
+
+//we validate text below
+RoundedButton.propTypes = {
+  text: PropTypes.string.isRequired,
+};
+
+export default RoundedButton;

--- a/src/pages/ConcertDetailsPage.jsx
+++ b/src/pages/ConcertDetailsPage.jsx
@@ -1,6 +1,6 @@
 import ItemDataPanel from '../components/ItemDataPanel';
 import LeftButton from '../components/buttons/LeftButton';
-import RightButton from '../components/buttons/RightButton';
+
 let imgURL =
   'https://images.pexels.com/photos/1387174/pexels-photo-1387174.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1';
 function ConcertDetailsPage() {

--- a/src/pages/ConcertDetailsPage.jsx
+++ b/src/pages/ConcertDetailsPage.jsx
@@ -7,18 +7,18 @@ function ConcertDetailsPage() {
   return (
     // Div below need to be adjusted for thir CSS properties when integrating this component to the app
     //Right now its position is absolute so might intergere with other components
-    <div className="container flex flex-col md:flex-row w-full min-h-screen mx-0 my-0 bg-white">
-      <section className="flex flex-col justify-evenly m-2 p-2">
-        <div className='flex items-center justify-center h-2/3 border-2 bg-gray-100 rounded rounded-lg p-2 mb-2 md:mb-inherit'>
+    <section className=" container flex flex-col w-full min-h-screen mx-0 my-0 bg-white">
+      <article className=" flex flex-col md:flex-row m-2 p-2 ">
+        <div className="flex items-center justify-center h-2/3 border-2 bg-gray-100 rounded rounded-lg p-2 mb-2 md:mb-inherit">
           <img src={imgURL} alt="concert" className="rounded-lg max-h-full" />
         </div>
 
-        <div className="container flex justify-between">
-          <LeftButton />
+        <div className="container flex justify-between md:w-1/3">
+          <ItemDataPanel />
         </div>
-      </section>
-      <ItemDataPanel />
-    </div>
+      </article>
+      <LeftButton />
+    </section>
   );
 }
 

--- a/src/pages/ConcertDetailsPage.jsx
+++ b/src/pages/ConcertDetailsPage.jsx
@@ -1,0 +1,25 @@
+import ItemDataPanel from '../components/ItemDataPanel';
+import LeftButton from '../components/buttons/LeftButton';
+import RightButton from '../components/buttons/RightButton';
+let imgURL =
+  'https://images.pexels.com/photos/1387174/pexels-photo-1387174.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1';
+function ConcertDetailsPage() {
+  return (
+    // Div below need to be adjusted for thir CSS properties when integrating this component to the app
+    //Right now its position is absolute so might intergere with other components
+    <div className="container flex flex-col md:flex-row w-full min-h-screen mx-0 my-0 bg-white">
+      <section className="flex flex-col justify-evenly m-2 p-2">
+        <div className='flex items-center justify-center h-2/3 border-2 bg-gray-100 rounded rounded-lg p-2 mb-2 md:mb-inherit'>
+          <img src={imgURL} alt="concert" className="rounded-lg max-h-full" />
+        </div>
+
+        <div className="container flex justify-between">
+          <LeftButton />
+        </div>
+      </section>
+      <ItemDataPanel />
+    </div>
+  );
+}
+
+export default ConcertDetailsPage;


### PR DESCRIPTION
# Implemented Changes:

- [x] Create `Concert Details`/`items-details` first version layout
    - [x] Include Panel with placeholder data for current concert (No logic yet, only layout)
    - [x] Include placeholder image (no logic yet, generig img)
    - [x] include `reserve` button instead of config (only layout)
    - [x] Include a gob back button (only layout)
    - [x] Page is responsive

![image](https://github.com/Diegogagan2587/Book-a-concert-front-end/assets/61764778/6bfc9431-a00f-4cc7-96fb-bd898b31825a)

![image](https://github.com/Diegogagan2587/Book-a-concert-front-end/assets/61764778/8b7075b9-c1b0-4709-a726-08e9d5be4e8c)

