### PR TITLE
Feat/item page or concert details [ Logic ]

### DIFF
--- a/src/components/ItemDataPanel.jsx
+++ b/src/components/ItemDataPanel.jsx
@@ -39,7 +39,7 @@ function ItemDataPanel(props) {
       </div>
       <div className="container flex justify-end  w-full">
         <RoundedButton
-          onClick={()=>dispatch(reservedConcert())}
+          onClick={()=>console.log("Reserve button clicked")}
           text="Reserve"
         />
       </div>

--- a/src/components/ItemDataPanel.jsx
+++ b/src/components/ItemDataPanel.jsx
@@ -1,17 +1,13 @@
 import RoundedButton from './buttons/RoundedButton';
 
-function ItemDataPanel() {
+function ItemDataPanel(props) {
+  const { title, organizer_id, description, price, date, city } = props.concert;
   return (
     <section className="flex flex-col gap-5 md:justify-between md:h-2/3 m-2 p-x-2 p-y-6">
       <div className="flex flex-col gap-5 ">
         <div>
-          <h1 className="text-xl text-end font-bold">
-            Mozart&apos;s tribute concert
-          </h1>
-          <p className="text-sm text-right">
-            Enjoy of a Mozart presentation with 3d visual effect rendering
-            mozart like live action generated with AI
-          </p>
+          <h1 className="text-xl text-end font-bold">{title}</h1>
+          <p className="text-sm text-right">{description}</p>
         </div>
 
         <div className="container shadow-md">
@@ -19,19 +15,19 @@ function ItemDataPanel() {
             <tbody>
               <tr className="bg-neutral-100">
                 <td>Organized by:</td>
-                <td>Mr.Rock</td>
+                <td>{organizer_id}</td>
               </tr>
               <tr>
                 <td>Date:</td>
-                <td>11-Jan-2100</td>
+                <td>{date} </td>
               </tr>
               <tr className="bg-neutral-100">
                 <td>City:</td>
-                <td>New York</td>
+                <td>{city}</td>
               </tr>
               <tr>
                 <td>Price:</td>
-                <td>$ 120.00</td>
+                <td>{price}</td>
               </tr>
             </tbody>
           </table>

--- a/src/components/ItemDataPanel.jsx
+++ b/src/components/ItemDataPanel.jsx
@@ -1,7 +1,11 @@
+import{ PropTypes } from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { reservedConcert } from '../redux/concertDetails/concertDetailsSlice';
 import RoundedButton from './buttons/RoundedButton';
 
 function ItemDataPanel(props) {
-  const { title, organizer_id, description, price, date, city } = props.concert;
+  const { title, organizer, description, price, date, city } = props.concert;
+  const dispatch = useDispatch();
   return (
     <section className="flex flex-col gap-5 md:justify-between md:h-2/3 m-2 p-x-2 p-y-6">
       <div className="flex flex-col gap-5 ">
@@ -15,7 +19,7 @@ function ItemDataPanel(props) {
             <tbody>
               <tr className="bg-neutral-100">
                 <td>Organized by:</td>
-                <td>{organizer_id}</td>
+                <td>{organizer}</td>
               </tr>
               <tr>
                 <td>Date:</td>
@@ -34,10 +38,25 @@ function ItemDataPanel(props) {
         </div>
       </div>
       <div className="container flex justify-end  w-full">
-        <RoundedButton text="Reserve" />
+        <RoundedButton
+          onClick={()=>dispatch(reservedConcert())}
+          text="Reserve"
+        />
       </div>
     </section>
   );
 }
+
+// We validate props below
+ItemDataPanel.propTypes = {
+  concert: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    organizer: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    price: PropTypes.string.isRequired,
+    date: PropTypes.string.isRequired,
+    city: PropTypes.string.isRequired,
+  }),
+};
 
 export default ItemDataPanel;

--- a/src/components/ItemDataPanel.jsx
+++ b/src/components/ItemDataPanel.jsx
@@ -1,11 +1,8 @@
 import{ PropTypes } from 'prop-types';
-import { useDispatch } from 'react-redux';
-import { reservedConcert } from '../redux/concertDetails/concertDetailsSlice';
 import RoundedButton from './buttons/RoundedButton';
 
 function ItemDataPanel(props) {
   const { title, organizer, description, price, date, city } = props.concert;
-  const dispatch = useDispatch();
   return (
     <section className="flex flex-col gap-5 md:justify-between md:h-2/3 m-2 p-x-2 p-y-6">
       <div className="flex flex-col gap-5 ">

--- a/src/components/buttons/RoundedButton.jsx
+++ b/src/components/buttons/RoundedButton.jsx
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types';
 
-function RoundedButton({ text }) {
+function RoundedButton({ text, onClick }) {
   return (
-    <button
+    <button 
+      onClick={onClick}
       className="container flex space-x-2 items-center w-28 md:w-40 py-1
         bg-[#94bc0c] border-white border-solid border-2 text-white
       rounded-xl md:rounded-2xl px-4
@@ -21,6 +22,7 @@ function RoundedButton({ text }) {
 //we validate text below
 RoundedButton.propTypes = {
   text: PropTypes.string.isRequired,
+  onClick: PropTypes.func,
 };
 
 export default RoundedButton;

--- a/src/pages/ConcertDetailsPage.jsx
+++ b/src/pages/ConcertDetailsPage.jsx
@@ -1,9 +1,18 @@
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
+import getConcert from '../redux/requests/getConcert';
 import ItemDataPanel from '../components/ItemDataPanel';
 import LeftButton from '../components/buttons/LeftButton';
+import { useEffect } from 'react';
 
 function ConcertDetailsPage() {
+  const dispatch = useDispatch();
   const concert = useSelector((state) => state.concertDetails);
+  
+ //getConcert will be called with the id of the concert that is clicked on the ConcertsPage
+  useEffect(() => {
+    dispatch(getConcert(1));
+  }, []);
+
   return (
     // Div below need to be adjusted for thir CSS properties when integrating this component to the app
     //Right now its position is absolute so might intergere with other components

--- a/src/pages/ConcertDetailsPage.jsx
+++ b/src/pages/ConcertDetailsPage.jsx
@@ -1,20 +1,24 @@
+import { useSelector } from 'react-redux';
 import ItemDataPanel from '../components/ItemDataPanel';
 import LeftButton from '../components/buttons/LeftButton';
 
-let imgURL =
-  'https://images.pexels.com/photos/1387174/pexels-photo-1387174.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1';
 function ConcertDetailsPage() {
+  const concert = useSelector((state) => state.concertDetails);
   return (
     // Div below need to be adjusted for thir CSS properties when integrating this component to the app
     //Right now its position is absolute so might intergere with other components
     <section className=" container flex flex-col w-full min-h-screen mx-0 my-0 bg-white">
       <article className=" flex flex-col md:flex-row m-2 p-2 ">
         <div className="flex items-center justify-center h-2/3 border-2 bg-gray-100 rounded rounded-lg p-2 mb-2 md:mb-inherit">
-          <img src={imgURL} alt="concert" className="rounded-lg max-h-full" />
+          <img
+            src={concert.img}
+            alt="concert"
+            className="rounded-lg max-h-full"
+          />
         </div>
 
         <div className="container flex justify-between md:w-1/3">
-          <ItemDataPanel />
+          <ItemDataPanel concert={concert} />
         </div>
       </article>
       <LeftButton />

--- a/src/redux/concertDetails/concertDetailsSlice.js
+++ b/src/redux/concertDetails/concertDetailsSlice.js
@@ -1,22 +1,35 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+//Placeholder State: remove after connecting to backend
+const initialState = {
+  id: 1,
+  title: 'Test - Ariana Grande Live Concert',
+  organizer: 'Test - Mr. Satan',
+  description:
+    'test: Ariana Concert: Ariana Grande is an American singer, songwriter, and actress. A multi-platinum, Grammy Award-winning recording artist, she is known for her wide vocal range, which critics have often compared to that of Mariah Carey.',
+  img: 'https://images.pexels.com/photos/1387174/pexels-photo-1387174.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1',
+  price: '100.0',
+  date: '2021-10-10',
+  city: 'Test - New York',
+  created_at: '2023-11-08T05:48:47.047Z',
+  updated_at: '2023-11-08T05:48:47.047Z',
+};
+
 export const concertDetailsSlice = createSlice({
   name: 'concertDetails',
-  initialState: {
-    concertDetails: {},
-  },
+  initialState,
   reducers: {
     //reducers functions here
-    fetchConcert: (state, action) => {
+    fetchedConcert: (state, action) => {
       //logic here example:
       //state.concertDetails = action.payload;
     },
-    reserveConcert: (state, action) => {
+    reservedConcert: (state, action) => {
       //logic here example:
       //state.concertDetails = action.payload;
     },
   },
 });
 
-export const { fetchConcert, reserveConcert } = concertDetailsSlice.actions;
+export const { fetchedConcert, reservedConcert } = concertDetailsSlice.actions;
 export default concertDetailsSlice.reducer;

--- a/src/redux/concertDetails/concertDetailsSlice.js
+++ b/src/redux/concertDetails/concertDetailsSlice.js
@@ -32,7 +32,6 @@ export const concertDetailsSlice = createSlice({
   extraReducers: (builder) => {
     //extraReducers functions here
     builder.addCase('getConcert/fulfilled', (state, action) => {
-      console.log('Running --> concertDetailsSlice.js: action.payload: ', action.payload);
       return { ...state, ...action.payload};
     });
   },

--- a/src/redux/concertDetails/concertDetailsSlice.js
+++ b/src/redux/concertDetails/concertDetailsSlice.js
@@ -1,22 +1,22 @@
-import {createSlice} from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
 
 export const concertDetailsSlice = createSlice({
-    name: 'concertDetails',
-    initialState: {
-        concertDetails: {}
-    },
-    reducers: {
+  name: 'concertDetails',
+  initialState: {
+    concertDetails: {},
+  },
+  reducers: {
     //reducers functions here
     fetchConcert: (state, action) => {
-        //logic here example:
-        //state.concertDetails = action.payload;
+      //logic here example:
+      //state.concertDetails = action.payload;
     },
     reserveConcert: (state, action) => {
-        //logic here example:
-        //state.concertDetails = action.payload;
+      //logic here example:
+      //state.concertDetails = action.payload;
     },
-})
+  },
+});
 
-
-export const {fetchConcert, reserveConcert} = concertDetailsSlice.actions;
+export const { fetchConcert, reserveConcert } = concertDetailsSlice.actions;
 export default concertDetailsSlice.reducer;

--- a/src/redux/concertDetails/concertDetailsSlice.js
+++ b/src/redux/concertDetails/concertDetailsSlice.js
@@ -19,15 +19,6 @@ export const concertDetailsSlice = createSlice({
   name: 'concertDetails',
   initialState,
   reducers: {
-    //reducers functions here
-    fetchedConcert: (state, action) => {
-      //logic here example:
-      //state.concertDetails = action.payload;
-    },
-    reservedConcert: (state, action) => {
-      //logic here example:
-      //state.concertDetails = action.payload;
-    },
   },
   extraReducers: (builder) => {
     //extraReducers functions here

--- a/src/redux/concertDetails/concertDetailsSlice.js
+++ b/src/redux/concertDetails/concertDetailsSlice.js
@@ -1,0 +1,22 @@
+import {createSlice} from '@reduxjs/toolkit';
+
+export const concertDetailsSlice = createSlice({
+    name: 'concertDetails',
+    initialState: {
+        concertDetails: {}
+    },
+    reducers: {
+    //reducers functions here
+    fetchConcert: (state, action) => {
+        //logic here example:
+        //state.concertDetails = action.payload;
+    },
+    reserveConcert: (state, action) => {
+        //logic here example:
+        //state.concertDetails = action.payload;
+    },
+})
+
+
+export const {fetchConcert, reserveConcert} = concertDetailsSlice.actions;
+export default concertDetailsSlice.reducer;

--- a/src/redux/concertDetails/concertDetailsSlice.js
+++ b/src/redux/concertDetails/concertDetailsSlice.js
@@ -29,6 +29,13 @@ export const concertDetailsSlice = createSlice({
       //state.concertDetails = action.payload;
     },
   },
+  extraReducers: (builder) => {
+    //extraReducers functions here
+    builder.addCase('getConcert/fulfilled', (state, action) => {
+      console.log('Running --> concertDetailsSlice.js: action.payload: ', action.payload);
+      return { ...state, ...action.payload};
+    });
+  },
 });
 
 export const { fetchedConcert, reservedConcert } = concertDetailsSlice.actions;

--- a/src/redux/requests/getConcert.js
+++ b/src/redux/requests/getConcert.js
@@ -4,10 +4,8 @@ const API_URL_BASE = 'https://book-a-concert-api.onrender.com';
 const GET_CONCERT_URL = `${API_URL_BASE}/concerts/`;
 
 const getConcert = createAsyncThunk('getConcert', async (concert_id) => {
-  console.log('Running --> getConcert.js: concert_id: ', concert_id);
   const response = await fetch(`${GET_CONCERT_URL}/${concert_id}`);
   const data = await response.json();
-  await console.log(data)
   return data;
 });
 

--- a/src/redux/requests/getConcert.js
+++ b/src/redux/requests/getConcert.js
@@ -1,0 +1,14 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+
+const API_URL_BASE = 'https://book-a-concert-api.onrender.com';
+const GET_CONCERT_URL = `${API_URL_BASE}/concerts/`;
+
+const getConcert = createAsyncThunk('getConcert', async (concert_id) => {
+  console.log('Running --> getConcert.js: concert_id: ', concert_id);
+  const response = await fetch(`${GET_CONCERT_URL}/${concert_id}`);
+  const data = await response.json();
+  await console.log(data)
+  return data;
+});
+
+export default getConcert;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,8 +1,10 @@
 import { configureStore } from '@reduxjs/toolkit';
+import concertDetailsReducer from './concertDetails/concertDetailsSlice';
 
 const store = configureStore({
   reducer: {
     //slices here
+    concertDetails: concertDetailsReducer,
   },
 });
 


### PR DESCRIPTION
# Implemented Changes:

- [ ] Implement Logic
    - [ ] Retrieve Current Concert Details



Notes: 
- This component only retrieves the concert with id 1, once other components are done, I will integrate this component in another pull request.(but you can swit to another id and if the concert exist it will work of course)
- regarding the reserve button, it will redirect to form but since routing is not implemented yet that feature was not included yet, it will be included in another pull request once `navigation` is implemented