### PR TITLE
Fix/concert details reserve organizer

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,8 +6,15 @@ import ReserveConcertPage from './pages/ReserveConcertPage';
 import Login from './components/Login';
 import Signup from './components/Signup';
 import NavigationPanel from './components/NavigationPanel';
+import { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import getOrganizers from './redux/requests/getOrganizers';
 
 function App() {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(getOrganizers());
+  }, []);
   return (
     <Router>
       <div className='App'>

--- a/src/components/ItemDataPanel.jsx
+++ b/src/components/ItemDataPanel.jsx
@@ -7,7 +7,6 @@ function ItemDataPanel(props) {
   const navigate = useNavigate();
 
   const handleReserveClick = () => {
-    console.log("Reserve button clicked")
     navigate('/reserve');
   }
   

--- a/src/components/ItemDataPanel.jsx
+++ b/src/components/ItemDataPanel.jsx
@@ -1,8 +1,16 @@
 import{ PropTypes } from 'prop-types';
 import RoundedButton from './buttons/RoundedButton';
+import {useNavigate} from 'react-router-dom';
 
 function ItemDataPanel(props) {
   const { title, organizer, description, price, date, city } = props.concert;
+  const navigate = useNavigate();
+
+  const handleReserveClick = () => {
+    console.log("Reserve button clicked")
+    navigate('/reserve');
+  }
+  
   return (
     <section className="flex flex-col gap-5 md:justify-between md:h-2/3 m-2 p-x-2 p-y-6">
       <div className="flex flex-col gap-5 ">
@@ -36,7 +44,7 @@ function ItemDataPanel(props) {
       </div>
       <div className="container flex justify-end  w-full">
         <RoundedButton
-          onClick={()=>console.log("Reserve button clicked")}
+          onClick={()=>handleReserveClick()}
           text="Reserve"
         />
       </div>

--- a/src/components/ItemDataPanel.jsx
+++ b/src/components/ItemDataPanel.jsx
@@ -24,7 +24,7 @@ function ItemDataPanel(props) {
             <tbody>
               <tr className="bg-neutral-100">
                 <td>Organized by:</td>
-                <td>{organizer}</td>
+                <td>{organizer.name}</td>
               </tr>
               <tr>
                 <td>Date:</td>

--- a/src/components/buttons/LeftButton.jsx
+++ b/src/components/buttons/LeftButton.jsx
@@ -1,6 +1,9 @@
-function LeftButton() {
+import PropTypes from "prop-types";
+
+function LeftButton({onClick}) {
   return (
     <button
+      onClick={onClick}
       className="flex items-center justify-end text-xl w-16 md:w-20 py-1 
   bg-[#94bc0c] border-white border-solid border-2 text-white
 rounded-r-xl md:rounded-r-2xl px-4
@@ -11,5 +14,10 @@ transition duration-500 ease-in-out"
     </button>
   );
 }
+
+//we validate text below
+LeftButton.propTypes = {
+  onClick: PropTypes.func,
+};
 
 export default LeftButton;

--- a/src/pages/ConcertDetailsPage.jsx
+++ b/src/pages/ConcertDetailsPage.jsx
@@ -15,6 +15,9 @@ function ConcertDetailsPage() {
     dispatch(getConcert(id)); 
   }, [id, dispatch]);
 
+  if(concert.status === 'loading') return (<div className="flex justify-center items-center h-screen text-red-500">Loading...</div>)
+  if(concert.status === 'error') return (<div className="flex justify-center items-center h-screen text-red-500">Something went wrong...</div>)
+
   return (
     // Div below need to be adjusted for thir CSS properties when integrating this component to the app
     //Right now its position is absolute so might intergere with other components

--- a/src/pages/ConcertDetailsPage.jsx
+++ b/src/pages/ConcertDetailsPage.jsx
@@ -1,5 +1,5 @@
 import { useSelector, useDispatch } from 'react-redux';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import getConcert from '../redux/requests/getConcert';
 import ItemDataPanel from '../components/ItemDataPanel';
 import LeftButton from '../components/buttons/LeftButton';
@@ -7,6 +7,7 @@ import { useEffect } from 'react';
 
 function ConcertDetailsPage() {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const { id } = useParams(); // Obtiene el ID del concierto de la URL
   const concert = useSelector((state) => state.concertDetails);
 
@@ -31,7 +32,7 @@ function ConcertDetailsPage() {
           <ItemDataPanel concert={concert} />
         </div>
       </article>
-      <LeftButton />
+      <LeftButton onClick={()=>navigate('/')}/>
     </section>
   );
 }

--- a/src/redux/concertDetails/concertDetailsSlice.js
+++ b/src/redux/concertDetails/concertDetailsSlice.js
@@ -33,6 +33,20 @@ export const concertDetailsSlice = createSlice({
     builder.addCase('getConcert/pending', (state) => {
       return { ...state, status: 'loading' };
     });
+
+    builder.addCase('getOrganizers/fulfilled', (state, action) => {
+      console.log('running getOrganizers----->>',action.payload);
+      //we find the organizer that matches the concert organizer
+      const organizer = action.payload.find((organizer) => organizer.id === state.organizer_id);
+      const newState = {
+        organizer: organizer,
+        organizers : action.payload,
+      };
+      return { ...state, ...newState };
+    });
+    builder.addCase('getOrganizers/rejected', (state) => {
+      return { ...state, organizer: 'Not found' };
+    });
   },
 });
 

--- a/src/redux/concertDetails/concertDetailsSlice.js
+++ b/src/redux/concertDetails/concertDetailsSlice.js
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 //Placeholder State: remove after connecting to backend
 const initialState = {
+  status: 'idle',
   id: 1,
   title: 'Test - Ariana Grande Live Concert',
   organizer: 'Test - Mr. Satan',
@@ -23,7 +24,14 @@ export const concertDetailsSlice = createSlice({
   extraReducers: (builder) => {
     //extraReducers functions here
     builder.addCase('getConcert/fulfilled', (state, action) => {
-      return { ...state, ...action.payload};
+      const newState = {...action.payload, status: 'success'};
+      return { ...state, ...newState };
+    });
+    builder.addCase('getConcert/rejected', (state) => {
+      return { ...state, status: 'error' };
+    });
+    builder.addCase('getConcert/pending', (state) => {
+      return { ...state, status: 'loading' };
     });
   },
 });

--- a/src/redux/requests/getOrganizers.js
+++ b/src/redux/requests/getOrganizers.js
@@ -1,0 +1,12 @@
+import { createAsyncThunk } from "@reduxjs/toolkit";
+
+const API_URL_BASE = "https://book-a-concert-api.onrender.com";
+const GET_USERS_URL = `${API_URL_BASE}/users/`;
+
+const getOrganizers = createAsyncThunk("getOrganizers", async () => {
+    const response = await fetch(GET_USERS_URL);
+    const data = await response.json();
+    return data;
+});
+
+export default getOrganizers;


### PR DESCRIPTION
# Implemented Changes
- [x] ConcertDetailsPage.jsx
    - [x] Update `go back` or `Left button` to redirect to home `/`
    - [x] Fix Error: Showing previous rendered concert, instead will show a loading screen when still loading
    - [x] ItemDataPanel.jsx
        - [x] Update Reserve button for redirecting to ReservePage
        - [x] display organizer.name
        
 _Note_ The reservation form will display a preselected concert, but that feature will be implemented in another pull, this component only will redirect for now.