### PR TITLE
Fix: Transform the image of Main page to fill the parent container

### DIFF
--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -49,7 +49,7 @@ function MainPage() {
   return (
     <div className="main-page box-border h-full flex flex-col justify-between py-10">
       <h2 className="text-center text-4xl my-2">Available Concerts</h2>
-      <p className='text-center text-slate-500 my-2'>Please Select and event</p>
+      <p className='text-center text-slate-500 my-2'>Please select an event</p>
       <Slider {...settings}>
         {concerts.map((concert) => (
           <div key={concert.id} >
@@ -59,12 +59,12 @@ function MainPage() {
                   <img
                     src={concert.img}
                     alt={concert.title}
-                    className="rounded-lg"
+                    className="rounded-full w-full h-full object-cover"
                   />
                 </div>
-                <div className='flex-1'>
-                  <h2 className="text-xl font-bold">{concert.title}</h2>
-                  <p className='text-sm'>{concert.description}</p>
+                <div className='flex-1 flex flex-col justify-around '>
+                  <h2 className="text-lg font-bold">{concert.title}</h2>
+                  <p className='text-xs'>{concert.description}</p>
                 </div>
               </div>
             </Link>


### PR DESCRIPTION
## In this PR, I've:
- Fix some grammar errors
- Edit the Tailwind code of `MainPage.jsx` to make the images of the concerts 100% rounded.
- Before: 
![image](https://github.com/Diegogagan2587/Book-a-concert-front-end/assets/116839451/e992c273-b8da-48fd-bbcc-f8d55f1309a6)
- After: 
![image](https://github.com/Diegogagan2587/Book-a-concert-front-end/assets/116839451/d6a0e4d5-5a4b-4b6f-8c9d-61ec6db59063)
