### PR TITLE
Fix/height-concert-detals

### DIFF
--- a/src/pages/ConcertDetailsPage.jsx
+++ b/src/pages/ConcertDetailsPage.jsx
@@ -21,17 +21,17 @@ function ConcertDetailsPage() {
   return (
     // Div below need to be adjusted for thir CSS properties when integrating this component to the app
     //Right now its position is absolute so might intergere with other components
-    <section className=" container flex flex-col w-full min-h-screen mx-0 my-0 bg-white">
+    <section className=" container flex flex-col md:justify-center w-full min-h-screen mx-0 my-0 bg-white">
       <article className=" flex flex-col md:flex-row md:justify-between m-2 p-2 ">
-        <div className="flex items-center justify-center max-h-2/3 min-h-full md:w-3/4 border-2 bg-gray-100 rounded rounded-lg p-2 mb-2 md:mb-inherit">
+        <div className="flex items-center justify-center h-56 sm:h-96 w-4/5 md:w-3/4 border-2 bg-gray-400 rounded rounded-lg p-2 mb-2 md:mb-inherit mx-auto">
           <img
             src={concert.img}
             alt="concert"
-            className="rounded-lg max-h-full"
+            className="rounded-lg w-full h-full object-cover"
           />
         </div>
 
-        <div className="container flex justify-between md:w-1/3">
+        <div className="container flex justify-center md:w-1/3">
           <ItemDataPanel concert={concert} />
         </div>
       </article>


### PR DESCRIPTION
# Implmented Changes
- [x] Set default height for IMG container within the Concert Details page to improve ressponsiveness and styling
- [x] Img will not stretch but will cover
- [x] Align the full Section in the middle of the y-axis.

## Before
![image](https://github.com/Diegogagan2587/Book-a-concert-front-end/assets/61764778/88aa3f6c-6b61-4329-b755-29db410189cf)

## After
![image](https://github.com/Diegogagan2587/Book-a-concert-front-end/assets/61764778/d69db1bf-744c-493d-a174-21ee37b12cb2)
![image](https://github.com/Diegogagan2587/Book-a-concert-front-end/assets/61764778/a6105608-afcc-462c-90e6-c54576d4f7a1)

