### PR TITLE
Fix/carousel view error

### DIFF
--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -16,7 +16,7 @@ function MainPage() {
     dots: true,
     infinite: true,
     speed: 500,
-    slidesToShow: 3, // Adjust the number of slides to show
+    slidesToShow: concerts.length > 3 ? 3 : concerts.length > 2 ? 2 : 1, // Adjust the number of slides to show
     slidesToScroll: 1,
     centerMode: true,
     prevArrow: <LeftButton />,

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -16,7 +16,7 @@ function MainPage() {
     dots: true,
     infinite: true,
     speed: 500,
-    slidesToShow: concerts.length > 3 ? 3 : concerts.length > 2 ? 2 : 1, // Adjust the number of slides to show
+    slidesToShow: (concerts && concerts.length) > 3 ? 3 : (concerts && concerts.length > 2 ? 2 : 1), // Adjust the number of slides to show
     slidesToScroll: 1,
     centerMode: true,
     prevArrow: <LeftButton />,


### PR DESCRIPTION
# Implemented Changes:

Fix carousel error: not displaying correctly when less than 4 concerts
- It Will display 1, 2, or 3 cards depending on how many concerts do exist.
- When concerts are more than 3, then it would work as usual.

The but is caused because the carousel does not work properly when 3 or less cards, so, we if we have less than 4 cards, then we need to specify the number of cards to render using a condition.



### Before
![image](https://github.com/Diegogagan2587/Book-a-concert-front-end/assets/61764778/a23ec36b-8a5d-4d75-9dca-8af63942ffb4)

### After

![image](https://github.com/Diegogagan2587/Book-a-concert-front-end/assets/61764778/58082e51-d90d-4e48-b662-2104336787a5)

