### PR TITLE
Refactor/env variables && Fix Prombelms when testing with Jest

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,8 +31,5 @@
   "ignorePatterns": [
     "dist/",
     "build/"
-  ],
-  "globals": {
-    "process": true
-  }
+  ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,5 +31,8 @@
   "ignorePatterns": [
     "dist/",
     "build/"
-  ]
+  ],
+  "globals": {
+    "process": true
+  }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,8 +2,7 @@
   "env": {
     "browser": true,
     "es6": true,
-    "jest": true,
-    "node": true
+    "jest": true
   },
   "parser": "@babel/eslint-parser",
   "parserOptions": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
   "env": {
     "browser": true,
     "es6": true,
-    "jest": true
+    "jest": true,
+    "node": true
   },
   "parser": "@babel/eslint-parser",
   "parserOptions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,8 @@
         "stylelint-csstree-validator": "^1.9.0",
         "stylelint-scss": "^3.21.0",
         "tailwindcss": "^3.3.5",
-        "vite": "^4.4.5"
+        "vite": "^4.4.5",
+        "vite-plugin-environment": "^1.1.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -12469,6 +12470,15 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-environment": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-environment/-/vite-plugin-environment-1.1.3.tgz",
+      "integrity": "sha512-9LBhB0lx+2lXVBEWxFZC+WO7PKEyE/ykJ7EPWCq95NEcCpblxamTbs5Dm3DLBGzwODpJMEnzQywJU8fw6XGGGA==",
+      "dev": true,
+      "peerDependencies": {
+        "vite": ">= 2.7"
       }
     },
     "node_modules/walker": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "stylelint-csstree-validator": "^1.9.0",
     "stylelint-scss": "^3.21.0",
     "tailwindcss": "^3.3.5",
-    "vite": "^4.4.5"
+    "vite": "^4.4.5",
+    "vite-plugin-environment": "^1.1.3"
   }
 }

--- a/src/redux/slices/userSlice.js
+++ b/src/redux/slices/userSlice.js
@@ -1,4 +1,4 @@
-const API_URL_BASE = import.meta.env.VITE_API_URL_BASE ||'https://book-a-concert-api.onrender.com'; 
+const API_URL_BASE = process.env.VITE_API_URL_BASE ||'https://book-a-concert-api.onrender.com'; 
 // src/redux/slices/userSlice.js
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 

--- a/src/redux/slices/userSlice.js
+++ b/src/redux/slices/userSlice.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line 
 const API_URL_BASE = process.env.VITE_API_URL_BASE ||'https://book-a-concert-api.onrender.com'; 
 // src/redux/slices/userSlice.js
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,11 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import EnvironmentPlugin from 'vite-plugin-environment'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    EnvironmentPlugin(['VITE_API_URL_BASE',]),
+  ],
 })


### PR DESCRIPTION
# Implented Changes:
## Refactor how to  import env enviromments
- install `vite-plugin-environment` to make it possible to import elements using `process.env` instead of  `import.meta.env`
- Set up the `vite-plugin-environment` in `vite.config.js` to be able to pass env variables.
- Add `VITE_API_URL_BASE` in `vite.config.js` to make it accessible using the syntax `process.env.VITE_API_URL_BASE`
- Refactor userSlice.js to import the API URL using the next syntax `const API_URL_BASE = process.env.VITE_API_URL_BASE`

Previos changes were made to avoid problems when installing Jest for testing.
Read about `vite-plugin-environment` here https://github.com/ElMassimo/vite-plugin-environment