### PR TITLE
Feat/home page loading animation

### DIFF
--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import Slider from 'react-slick';
 import LeftButton from '../components/buttons/LeftButton';
 import RightButton from '../components/buttons/RightButton';
+import Loading from '../components/Loading';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import { setCurrentConcert } from '../redux/slices/concertSlice';
@@ -10,6 +11,7 @@ import { setCurrentConcert } from '../redux/slices/concertSlice';
 
 function MainPage() {
   const concerts = useSelector((state) => state.concerts.created);
+  const status = useSelector((state) => state.concerts.status);
   const dispatch = useDispatch();
 
   const settings = {
@@ -47,6 +49,9 @@ function MainPage() {
     <div className="main-page box-border h-full flex flex-col justify-between py-10">
       <h2 className="text-center text-4xl my-2">Available Concerts</h2>
       <p className='text-center text-slate-500 my-2'>Please select an event</p>
+      <div className='flex items-center justify-center'>
+      { status === 'loading' && <Loading /> }
+      </div>
       <Slider {...settings}>
         {concerts && concerts.map((concert) => (
           <div key={concert.id} onClick={() => dispatch(setCurrentConcert(concert))}>

--- a/src/redux/slices/concertSlice.js
+++ b/src/redux/slices/concertSlice.js
@@ -75,9 +75,15 @@ const concertSlice = createSlice({
         state.status = 'delete_failed';
       });
 
+      builder.addCase('getConcerts/pending',(state) => {
+        const newState = { status: 'loading' };
+        return {...state, ...newState};
+      })
+
       builder.addCase('getConcerts/fulfilled', (state, action) => {
         const newState = {
           created: action.payload,
+          status: 'fulfilled',
         };
         return { ...state, ...newState };
       });


### PR DESCRIPTION
# Implemented Changes:

- render the Loading component in the main page when the getConcert request is pending:
- Update status in concertSlice when the getConcert request is pending.

![image](https://github.com/Diegogagan2587/Book-a-concert-front-end/assets/61764778/42af0067-2306-4de3-97e1-dc0ba7d9686f)
