### PR TITLE
Update linters script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite --host",
     "build": "vite build",
-    "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "npx eslint '**/*.{js,jsx}' && npx stylelint '**/*.{css,scss}'",
     "preview": "vite preview",
     "test": "vitest"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite --host",
     "build": "vite build",
-    "lint": "npx eslint '**/*.{js,jsx}' && npx stylelint '**/*.{css,scss}'",
+    "lint": "npx eslint '**/*.{js,jsx}' || npx stylelint '**/*.{css,scss}'",
     "preview": "vite preview",
     "test": "vitest"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite --host",
     "build": "vite build",
-    "lint": "npx eslint '**/*.{js,jsx}' || npx stylelint '**/*.{css,scss}'",
+    "lint": "npx eslint '**/*.{js,jsx}' && npx stylelint '**/*.{css,scss}'",
     "preview": "vite preview",
     "test": "vitest"
   },


### PR DESCRIPTION
# Implemented Changes:

we have updated the script `lint` in `package.json` in order to run all installed linting tools on this project with 
a single command, son when you type `npm run lint` in your console the next linting tools will run:
- eslint
- styleint

This will avoid  the developer having to run `npx eslint "**/*.{js,jsx}"` and `npx stylelint "**/*.{css,scss}"` separately in 
the console, but run them together instead with a single command `npm run lint` which is easier to remember.
